### PR TITLE
refactory: remove strange type Id + publish BabelDesc.Version

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func connection(updates chan parser.SBabelUpdate, node string) {
 			if err != nil {
 				log.Printf("Error while listening %v:\n\t%v.\n", node, err)
 			}
-			ws.RemoveDesc(desc.Id())
+			ws.RemoveDesc(desc.ID)
 		}
 		afterHours()
 	}

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -11,28 +11,28 @@ import (
 
 type nodelist struct {
 	sync.Mutex
-	nodes map[parser.Id]*parser.BabelDesc
+	nodes map[string]*parser.BabelDesc
 }
 
 var nodes nodelist
 
 func Init() {
-	nodes.nodes = make(map[parser.Id]*parser.BabelDesc)
+	nodes.nodes = make(map[string]*parser.BabelDesc)
 }
 
 func AddDesc(d *parser.BabelDesc) {
 	nodes.Lock()
-	nodes.nodes[d.Id()] = d
+	nodes.nodes[d.ID] = d
 	nodes.Unlock()
 }
 
-func RemoveDesc(id parser.Id) {
+func RemoveDesc(id string) {
 	nodes.Lock()
 	delete(nodes.nodes, id)
 	nodes.Unlock()
 }
 
-func GetDesc(id parser.Id) *parser.BabelDesc {
+func GetDesc(id string) *parser.BabelDesc {
 	nodes.Lock()
 	defer nodes.Unlock()
 	return nodes.nodes[id]


### PR DESCRIPTION
There is no function bind on the `type Id string` or any other special thing.
So just make the code more unessesary complex.